### PR TITLE
Add 'always' option to kenyaui setupAjaxPost

### DIFF
--- a/omod/src/main/webapp/resources/scripts/kenyaui.js
+++ b/omod/src/main/webapp/resources/scripts/kenyaui.js
@@ -219,6 +219,9 @@ jQuery(function() {
 				.always(function() {
 					// Re-enable any submit buttons
 					form.find('[type="submit"]').prop('disabled', false);
+					if (options.always) {
+						options.always();
+					}
 				});
 		});
 	};


### PR DESCRIPTION
Add always option so as to allow clients of kenyaui setupAjaxPost to define functions that should be run every time a form submission is completed successfully or otherwise.
